### PR TITLE
Add unit tests for domain entities

### DIFF
--- a/src/types/domain/__tests__/Agent.test.ts
+++ b/src/types/domain/__tests__/Agent.test.ts
@@ -30,8 +30,8 @@ describe('Agent', () => {
       expect(agent.tasks).toEqual(validDTO.tasks)
     })
 
-    it.each(['teamId', 'id', 'roleId'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as AgentDTO
+    it.each(['id', 'teamId', 'roleId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as AgentDTO
       const result = Agent.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -41,7 +41,7 @@ describe('Agent', () => {
     })
 
     it('should return a DomainError if tasks contain invalid UUIDs', () => {
-      const invalidDTO: AgentDTO = { ...validDTO, tasks: ['bad-uuid'] }
+      const invalidDTO: AgentDTO = { ...validDTO, tasks: ['not-a-uuid'] }
       const result = Agent.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
@@ -69,7 +69,7 @@ describe('Agent', () => {
       expect(error.message).toContain('name')
     })
 
-    it.each(['teamId', 'roleId', 'name', 'tasks', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'teamId', 'roleId', 'name', 'tasks'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Agent.create(dto as AgentDTO)
 

--- a/src/types/domain/__tests__/Job.test.ts
+++ b/src/types/domain/__tests__/Job.test.ts
@@ -30,8 +30,8 @@ describe('Job', () => {
       expect(job.tasks).toEqual(validDTO.tasks)
     })
 
-    it.each(['phaseId', 'id'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as JobDTO
+    it.each(['id', 'phaseId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as JobDTO
       const result = Job.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -41,7 +41,7 @@ describe('Job', () => {
     })
 
     it('should return a DomainError if tasks contain invalid UUIDs', () => {
-      const invalidDTO: JobDTO = { ...validDTO, tasks: ['bad-uuid'] }
+      const invalidDTO: JobDTO = { ...validDTO, tasks: ['not-a-uuid'] }
       const result = Job.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
@@ -50,7 +50,7 @@ describe('Job', () => {
       expect(error.message).toContain('tasks')
     })
 
-    it.each(['phaseId', 'name', 'tasks', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'phaseId', 'name', 'tasks'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Job.create(dto as JobDTO)
 

--- a/src/types/domain/__tests__/Phase.test.ts
+++ b/src/types/domain/__tests__/Phase.test.ts
@@ -30,8 +30,8 @@ describe('Phase', () => {
       expect(phase.actions).toEqual(validDTO.actions)
     })
 
-    it.each(['teamId', 'id', 'jobId'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as PhaseDTO
+    it.each(['id', 'teamId', 'jobId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as PhaseDTO
       const result = Phase.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -41,7 +41,7 @@ describe('Phase', () => {
     })
 
     it('should return a DomainError if actions contain invalid UUIDs', () => {
-      const invalidDTO: PhaseDTO = { ...validDTO, actions: ['bad-uuid'] }
+      const invalidDTO: PhaseDTO = { ...validDTO, actions: ['not-a-uuid'] }
       const result = Phase.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
@@ -59,7 +59,7 @@ describe('Phase', () => {
       expect(phase.actions).toEqual([])
     })
 
-    it.each(['teamId', 'jobId', 'name', 'actions', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'teamId', 'jobId', 'name', 'actions'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Phase.create(dto as PhaseDTO)
 

--- a/src/types/domain/__tests__/Plan.test.ts
+++ b/src/types/domain/__tests__/Plan.test.ts
@@ -28,8 +28,8 @@ describe('Plan', () => {
       expect(plan.description).toBe(validDTO.description)
     })
 
-    it.each(['projectId', 'id'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as PlanDTO
+    it.each(['id', 'projectId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as PlanDTO
       const result = Plan.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -39,7 +39,7 @@ describe('Plan', () => {
     })
 
     it('should return a DomainError if phases contain invalid UUIDs', () => {
-      const invalidDTO: PlanDTO = { ...validDTO, phases: ['bad-uuid'] }
+      const invalidDTO: PlanDTO = { ...validDTO, phases: ['not-a-uuid'] }
       const result = Plan.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
@@ -66,7 +66,7 @@ describe('Plan', () => {
       expect(plan.description).toBeUndefined()
     })
 
-    it.each(['projectId', 'phases', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'projectId', 'phases'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Plan.create(dto as PlanDTO)
 

--- a/src/types/domain/__tests__/Project.test.ts
+++ b/src/types/domain/__tests__/Project.test.ts
@@ -28,8 +28,8 @@ describe('Project', () => {
       expect(project.description).toBe(validDTO.description)
     })
 
-    it.each(['planId', 'id'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as ProjectDTO
+    it.each(['id', 'planId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as ProjectDTO
       const result = Project.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -57,7 +57,7 @@ describe('Project', () => {
       expect(project.description).toBeUndefined()
     })
 
-    it.each(['planId', 'name', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'planId', 'name'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Project.create(dto as ProjectDTO)
 

--- a/src/types/domain/__tests__/Role.test.ts
+++ b/src/types/domain/__tests__/Role.test.ts
@@ -26,14 +26,14 @@ describe('Role', () => {
       expect(role.description).toBe(validDTO.description)
     })
 
-    it.each(['id'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as RoleDTO
-      const result = Role.create(dto)
+    it('should return a DomainError if id is not a valid UUID', () => {
+      const invalidDTO: RoleDTO = { ...validDTO, id: 'not-a-uuid' }
+      const result = Role.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
       const error = result._unsafeUnwrapErr()
       expect(error).toBeInstanceOf(DomainError)
-      expect(error.message).toContain(field)
+      expect(error.message).toContain('id')
     })
 
     it('should return a DomainError if name is empty', () => {
@@ -55,7 +55,7 @@ describe('Role', () => {
       expect(role.description).toBeUndefined()
     })
 
-    it.each(['name', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'name'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Role.create(dto as RoleDTO)
 

--- a/src/types/domain/__tests__/Task.test.ts
+++ b/src/types/domain/__tests__/Task.test.ts
@@ -32,8 +32,8 @@ describe('Task', () => {
       expect(task.description).toBe(validDTO.description)
     })
 
-    it.each(['validatorId', 'id', 'jobId', 'agentId'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as TaskDTO
+    it.each(['id', 'jobId', 'agentId', 'validatorId'])('should return a DomainError if %s is not a valid UUID', field => {
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as TaskDTO
       const result = Task.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -42,7 +42,7 @@ describe('Task', () => {
       expect(error.message).toContain(field)
     })
 
-    it.each(['jobId', 'agentId', 'validatorId', 'name', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'jobId', 'agentId', 'validatorId', 'name'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Task.create(dto as TaskDTO)
 

--- a/src/types/domain/__tests__/Team.test.ts
+++ b/src/types/domain/__tests__/Team.test.ts
@@ -29,7 +29,7 @@ describe('Team', () => {
     })
 
     it.each(['id', 'phaseId'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as TeamDTO
+      const dto = { ...validDTO, [field]: 'not-a-uuid' } as TeamDTO
       const result = Team.create(dto)
 
       expect(result.isErr()).toBe(true)
@@ -39,7 +39,7 @@ describe('Team', () => {
     })
 
     it('should return a DomainError if agents contain invalid UUIDs', () => {
-      const invalidDTO: TeamDTO = { ...validDTO, agents: ['bad-uuid'] }
+      const invalidDTO: TeamDTO = { ...validDTO, agents: ['not-a-uuid'] }
       const result = Team.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
@@ -57,7 +57,7 @@ describe('Team', () => {
       expect(team.agents).toEqual([])
     })
 
-    it.each(['phaseId', 'name', 'agents', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'phaseId', 'name', 'agents'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Team.create(dto as TeamDTO)
 

--- a/src/types/domain/__tests__/Validator.test.ts
+++ b/src/types/domain/__tests__/Validator.test.ts
@@ -26,14 +26,14 @@ describe('Validator', () => {
       expect(validator.resource).toBe(validDTO.resource)
     })
 
-    it.each(['id'])('should return a DomainError if %s is not a valid UUID', field => {
-      const dto = { ...validDTO, [field]: 'bad-uuid' } as ValidatorDTO
-      const result = Validator.create(dto)
+    it('should return a DomainError if id is not a valid UUID', () => {
+      const invalidDTO: ValidatorDTO = { ...validDTO, id: 'not-a-uuid' }
+      const result = Validator.create(invalidDTO)
 
       expect(result.isErr()).toBe(true)
       const error = result._unsafeUnwrapErr()
       expect(error).toBeInstanceOf(DomainError)
-      expect(error.message).toContain(field)
+      expect(error.message).toContain('id')
     })
 
     it('should return a DomainError if template is empty', () => {
@@ -46,7 +46,7 @@ describe('Validator', () => {
       expect(error.message).toContain('template')
     })
 
-    it.each(['resource', 'template', 'id'])('should return a DomainError if %s is missing', field => {
+    it.each(['id', 'resource', 'template'])('should return a DomainError if %s is missing', field => {
       const { [field]: _omit, ...dto } = validDTO as any
       const result = Validator.create(dto as ValidatorDTO)
 


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for domain entities following Action example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686972568d788331bbd31eaec0fb6820