### PR TITLE
Refactor startup to handle IpcMainEvents in a modular way

### DIFF
--- a/src/main/app/AppFacade.ts
+++ b/src/main/app/AppFacade.ts
@@ -1,6 +1,6 @@
 import { IFacade, Facade } from '@puremvc/puremvc-typescript-multicore-framework'
 import { ConsoleMediator } from './view/ConsoleMediator'
-import { StartupCommand } from './controller/StartupCommand'
+import { StartupCommand } from './controller/startup/StartupCommand'
 import { STARTUP } from './constants/AppConstants'
 
 export interface IAppFacade extends IFacade {
@@ -51,7 +51,7 @@ export class AppFacade extends Facade {
    */
   public startup(): void {
     this.log(`▶️ ${this.multitonKey}`)
-    this.log('🔱 AppFacade ')
+    this.log('🔱 AppFacade - Preparing Primary MVC Core')
     this.sendNotification(STARTUP)
   }
 

--- a/src/main/app/controller/api/PrefsCommand.ts
+++ b/src/main/app/controller/api/PrefsCommand.ts
@@ -1,0 +1,22 @@
+import { IAppFacade } from '../../AppFacade'
+import { ipcMain } from 'electron'
+import { INotification, SimpleCommand } from '@puremvc/puremvc-typescript-multicore-framework'
+
+export class PrefsCommand extends SimpleCommand {
+
+  public override execute(_note: INotification): void {
+    const f: IAppFacade = this.facade as IAppFacade
+    f.log('⚙️ PrefsCommand - Installing Prefs API Handlers', 2)
+
+    // Load preferences from file/storage
+    ipcMain.handle('load-prefs', () => {
+      return { theme: 'dark', language: 'en' }
+    })
+
+    // Save preferences to file/storage
+    ipcMain.handle('save-prefs', (_event, prefs) => {
+      console.log('Saving preferences:', prefs)
+    })
+
+  }
+}

--- a/src/main/app/controller/startup/PrepareControllerCommand.ts
+++ b/src/main/app/controller/startup/PrepareControllerCommand.ts
@@ -1,0 +1,26 @@
+import { AsyncMacroCommand } from '@puremvc/puremvc-typescript-util-async-command'
+import { INotification } from '@puremvc/puremvc-typescript-multicore-framework'
+import { IAppFacade } from '../../AppFacade'
+import { PrefsCommand } from '../api/PrefsCommand'
+
+export class PrepareControllerCommand extends AsyncMacroCommand {
+
+  /**
+   * Create the Controller command pipeline
+   * @override
+   */
+  public override initializeAsyncMacroCommand(): void {
+    this.addSubCommand(() => new PrefsCommand())
+  }
+
+  /**
+   * Execute the Controller pipeline
+   * @override
+   * @param {object} note the notification that triggered this command
+   */
+  public override execute(note: INotification): void {
+    const f: IAppFacade = this.facade as IAppFacade
+    f.log('⚙️ PrepareControllerCommand - Preparing API Handlers', 2)
+    super.execute(note)
+  }
+}

--- a/src/main/app/controller/startup/PrepareModelCommand.ts
+++ b/src/main/app/controller/startup/PrepareModelCommand.ts
@@ -1,6 +1,6 @@
 import { INotification, SimpleCommand } from '@puremvc/puremvc-typescript-multicore-framework'
-import { IAppFacade } from '../AppFacade'
-import { EnvProxy } from '../model/EnvProxy'
+import { IAppFacade } from '../../AppFacade'
+import { EnvProxy } from '../../model/EnvProxy'
 
 export class PrepareModelCommand extends SimpleCommand {
   /**

--- a/src/main/app/controller/startup/PrepareViewCommand.ts
+++ b/src/main/app/controller/startup/PrepareViewCommand.ts
@@ -1,17 +1,15 @@
 import { join } from 'path'
-import { IAppFacade } from '../AppFacade'
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
-import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { IAppFacade } from '../../AppFacade'
+import { app, shell, BrowserWindow } from 'electron'
+import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { INotification, SimpleCommand } from '@puremvc/puremvc-typescript-multicore-framework'
-import { EnvProxy } from '../model/EnvProxy'
+import { EnvProxy } from '../../model/EnvProxy'
 
 export class PrepareViewCommand extends SimpleCommand {
-  /**
-   * Create app window
-   */
+
   public override execute(_note: INotification): void {
     const f: IAppFacade = this.facade as IAppFacade
-    f.log('⚙️ PrepareViewCommand - Creating app window', 2)
+    f.log('⚙️ PrepareViewCommand - Creating Main App Window', 2)
 
     const envProxy = f.retrieveProxy(EnvProxy.NAME) as EnvProxy
 
@@ -42,7 +40,7 @@ export class PrepareViewCommand extends SimpleCommand {
       //const url = envProxy.varByKey('ELECTRON_RENDERER_URL');
       const url = envProxy.getVar('ELECTRON_RENDERER_URL')
 
-      if (is.dev && url) {
+      if (envProxy.isDev() && url) {
         mainWindow.loadURL(url)
         mainWindow.webContents.openDevTools({ mode: 'detach' })
       } else {
@@ -76,21 +74,6 @@ export class PrepareViewCommand extends SimpleCommand {
       app.on('activate', function () {
         if (BrowserWindow.getAllWindows().length === 0) createWindow()
       })
-    })
-
-    // IPC test
-    ipcMain.on('ping', () => console.log('pong'))
-
-    // TODO - move to PrepareControllerCommand
-    //  send a notification for each handler, passing the loaded data, handle with a command
-    // Load preferences from file/storage
-    ipcMain.handle('load-prefs', () => {
-      return { theme: 'dark', language: 'en' }
-    })
-
-    // Save preferences to file/storage
-    ipcMain.handle('save-prefs', (_event, prefs) => {
-      console.log('Saving preferences:', prefs)
     })
 
     // Create window

--- a/src/main/app/controller/startup/StartupCommand.ts
+++ b/src/main/app/controller/startup/StartupCommand.ts
@@ -2,25 +2,27 @@ import { AsyncMacroCommand } from '@puremvc/puremvc-typescript-util-async-comman
 import { INotification } from '@puremvc/puremvc-typescript-multicore-framework'
 import { PrepareModelCommand } from './PrepareModelCommand'
 import { PrepareViewCommand } from './PrepareViewCommand'
-import { IAppFacade } from '../AppFacade'
+import { PrepareControllerCommand } from './PrepareControllerCommand'
+import { IAppFacade } from '../../AppFacade'
 
 export class StartupCommand extends AsyncMacroCommand {
   /**
-   * Create the primary command pipeline for the App
+   * Create the startup command pipeline for the App
    * @override
    */
   public override initializeAsyncMacroCommand(): void {
     this.addSubCommand(() => new PrepareModelCommand())
     this.addSubCommand(() => new PrepareViewCommand())
+    this.addSubCommand(() => new PrepareControllerCommand())
   }
 
   /**
-   * Execute the primary command pipeline
+   * Execute the startup command pipeline
    * @override
    * @param {object} note the notification that triggered this command
    */
   public override execute(note: INotification): void {
-    ;(this.facade as IAppFacade).log('⚙️ StartupCommand - Running Subcommands', 1)
+    ;(this.facade as IAppFacade).log('⚙️ StartupCommand - Running Startup Subcommands', 1)
     super.execute(note)
   }
 }


### PR DESCRIPTION
* Refactor/move startup related commands into controller/startup
* Refactor/extract placeholder ipcMain handlers from PrepareViewCommand.ts into PrefsCommand.ts
* Add PrepareControllerCommand.ts as async command that runs subcommands from api folder, each of which will handle ipcMain requests for a section of the api